### PR TITLE
ADDED: preview scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ fzf :heart: preview
 
 ## Preview Everywhere
 
+This fork checks if the buffer is a scratch buffer and save it's contents so a preview can be shown.
+This allows preview, for example, of generated fles not saved yet or manpages.
+
+
 The preview functionality of **fzf** in vim is great. However, only limited
 commands of **fzf.vim** provide a preview window that you can press `ctrl-/` key
 to toggle. If you want to enhance your **fzf.vim** by enabling the preview

--- a/autoload/fzf_preview.vim
+++ b/autoload/fzf_preview.vim
@@ -23,16 +23,46 @@ function! fzf_preview#action_for(key, ...) abort
     return type(cmd) == type('') ? cmd : default
 endfunction
 
+function! fzf_preview#save_scratch()
+    let l:filename = tempname()
+    call writefile(getbufline('%', 1, '$'), l:filename)
+    return l:filename
+endfunction
+
 function! fzf_preview#p(bang, ...) abort
+
     let preview_args = get(g:, 'fzf_preview_window', ['right:50%', 'ctrl-/'])
+
     if empty(preview_args)
         return { 'options': ['--preview-window', 'hidden'] }
     endif
+
+    let d = call('fzf#vim#with_preview', extend(copy(a:000), preview_args))
 
     " For backward-compatiblity
     if type(preview_args) == type('')
         let preview_args = [preview_args]
     endif
+
+    " if in scratch buffer, override the options
+    if &buftype == 'nofile'
+        let l:filepath = fzf_preview#save_scratch()
+        let options_s = [ '--preview-window', '+{1}-/2', '--preview-window', 'up:60%', '--preview', 'bat --color always -l man -n -H +{1} --theme TwoDark ' . l:filepath, '--bind', 'ctrl-h:toggle-preview']
+        let options = { }
+        let options['options'] = options_s
+        return options
+    endif
+
+    " trying, without success to add options 
+    " if &buftype == 'nofile'
+    "     let l:filepath = fzf_preview#save_scratch()
+    "     let l:preview = 'bat --color always -l man -n -H +{1} --theme TwoDark ' . l:filepath
+	" echo preview_args
+    "     call extend(preview_args, ['--preview', l:preview])
+	" echo preview_args
+	" let userInput = input("input something:")
+    " endif
+    
     return call('fzf#vim#with_preview', extend(copy(a:000), preview_args))
 endfunction
 


### PR DESCRIPTION
Check if the buffer is a scratch buffer, save it's contents so we can show a preview.


The code is not taking care of previously set option, it overrides everything. All attempt to do it failed, first vimscript ever and hopefully last ;)